### PR TITLE
Add Docker APP_VERSION for Terra

### DIFF
--- a/.github/workflows/build_push_terra.yml
+++ b/.github/workflows/build_push_terra.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           load: true
           build-args: |
+            APP_VERSION=${{ needs.generate-tag.outputs.tag }}
             BUILD_VERSION=${{ github.sha }}-${{ github.run_attempt }}
           cache-from: type=gha,scope=${{ github.ref_name }}
           cache-to: type=gha,scope=${{ github.ref_name }},mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,10 @@ COPY --from=builder /home/nonroot/.local/lib /usr/lib/
 COPY --from=builder /app/*.py ./
 COPY --from=builder /app/src ./src/
 
-ARG BUILD_VERSION
-ENV BUILD_VERSION=${BUILD_VERSION:-latest}
+ARG APP_VERSION=latest
+ARG BUILD_VERSION=latest
+
+ENV APP_VERSION=${APP_VERSION} \
+    BUILD_VERSION=${BUILD_VERSION}
 
 ENTRYPOINT ["hypercorn", "app:app", "--bind", "0.0.0.0:8080"]


### PR DESCRIPTION
`APP_VERSION` defines the Docker tag with which the image is built (e.g. `v0.0.1`), whereas `BUILD_VERSION` defines the GitHub commit SHA and Actions run attempt #. Both of these can be useful to be able to pinpoint which version of the code the app is running. However, `APP_VERSION` is less accurate because the Docker tag may be overwritten by a rebuild (which may in turn pick up updated versions of dependencies etc.), and only `BUILD_VERSION` reflects that.