### PR TITLE
Cached QC param added to SFGWAS config

### DIFF
--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -288,6 +288,16 @@ SFGWAS_SHARED_PARAMETERS = {
             "description": "A binary value to use cached quality control results.",
             "value": "false",
     },
+    "use_cached_pca": {
+                "name": "Use Cached PCA Results",
+                "description": "A binary value to use cached principal component analysis results.",
+                "value": "false",
+    },
+    "use_cached_power_iter": {
+                    "name": "Use Cached Power Iteration Results",
+                    "description": "A binary value to use cached power iteration results.",
+                    "value": "false",
+    },
     "imiss_ub": {
         "name": "Individual Missing Rate Upper Bound",
         "description": "The individual missing rate upper bound.",
@@ -329,6 +339,8 @@ SFGWAS_SHARED_PARAMETERS = {
         "num_pcs_to_remove",
         "skip_qc",
         "use_cached_qc",
+        "use_cached_pca",
+        "use_cached_power_iter",
         "imiss_ub",
         "het_lb",
         "het_ub",

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -283,6 +283,11 @@ SFGWAS_SHARED_PARAMETERS = {
         "description": "A binary value to skip quality control and use all individuals/SNPs.",
         "value": "false",
     },
+    "use_cached_qc": {
+            "name": "Use Cached Quality Control",
+            "description": "A binary value to use cached quality control results.",
+            "value": "false",
+    },
     "imiss_ub": {
         "name": "Individual Missing Rate Upper Bound",
         "description": "The individual missing rate upper bound.",
@@ -323,6 +328,7 @@ SFGWAS_SHARED_PARAMETERS = {
         "num_covs",
         "num_pcs_to_remove",
         "skip_qc",
+        "use_cached_qc",
         "imiss_ub",
         "het_lb",
         "het_ub",

--- a/src/utils/schemas/parameters.py
+++ b/src/utils/schemas/parameters.py
@@ -43,6 +43,8 @@ sfgwas_shared_parameters_properties = {
     "num_pcs_to_remove": {"type": "integer", "minimum": 0, "maximum": 100},
     "skip_qc": {"type": "string", "enum": ["false", "true"]},
     "use_cached_qc": {"type": "string", "enum": ["false", "true"]},
+    "use_cached_pca": {"type": "string", "enum": ["false", "true"]},
+    "use_cached_power_iter": {"type": "string", "enum": ["false", "true"]},
     "imiss_ub": {"type": "number", "minimum": 0.0, "maximum": 1.0},
     "het_lb": {"type": "number", "minimum": 0.0, "maximum": 1.0},
     "het_ub": {"type": "number", "minimum": 0.0, "maximum": 1.0},

--- a/src/utils/schemas/parameters.py
+++ b/src/utils/schemas/parameters.py
@@ -42,6 +42,7 @@ sfgwas_shared_parameters_properties = {
     "num_covs": {"type": "integer", "minimum": 1, "maximum": 1000},
     "num_pcs_to_remove": {"type": "integer", "minimum": 0, "maximum": 100},
     "skip_qc": {"type": "string", "enum": ["false", "true"]},
+    "use_cached_qc": {"type": "string", "enum": ["false", "true"]},
     "imiss_ub": {"type": "number", "minimum": 0.0, "maximum": 1.0},
     "het_lb": {"type": "number", "minimum": 0.0, "maximum": 1.0},
     "het_ub": {"type": "number", "minimum": 0.0, "maximum": 1.0},


### PR DESCRIPTION
A new flag is added to SFGWAS general config: use_cached_qc.
It should be automatically added to the website UI.